### PR TITLE
Handle replay of unicode glyphs

### DIFF
--- a/playitagainsam/player.py
+++ b/playitagainsam/player.py
@@ -81,7 +81,7 @@ class Player(SocketCoordinator):
 
     def _do_write(self, term, data):
         view_sock = self.terminals[term][0]
-        view_sock.sendall(data)
+        view_sock.sendall(data.encode('utf8'))
 
 
 def join_player(sock_path, **kwds):


### PR DESCRIPTION
Unicode glyphs, such as those generated by Vim's powerline plugin, would
break the player since they could not be represented using the implicit ascii
encoding. This change switches to an explicit utf8 encoding instead.
