### PR TITLE
Don't use 2to3, it is not needed nor supported in setutpools 58+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ except ImportError:
     from distutils.core import setup
 else:
     setup_kwds["test_suite"] = "playitagainsam.tests"
-    if sys.version_info > (3,):
-        setup_kwds["use_2to3"] = True
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
    $ 2to3 --no-diffs --write --nobackups .
    RefactoringTool: Skipping optional fixer: buffer
    RefactoringTool: Skipping optional fixer: idioms
    RefactoringTool: Skipping optional fixer: set_literal
    RefactoringTool: Skipping optional fixer: ws_comma
    RefactoringTool: No changes to ./playitagainsam/__main__.py
    RefactoringTool: No changes to ./setup.py
    RefactoringTool: No changes to ./playitagainsam/coordinator.py
    RefactoringTool: No changes to ./playitagainsam/eventlog.py
    RefactoringTool: No changes to ./playitagainsam/__init__.py
    RefactoringTool: No changes to ./playitagainsam/recorder.py
    RefactoringTool: No changes to ./playitagainsam/util.py
    RefactoringTool: No changes to ./playitagainsam/player.py
    RefactoringTool: No files need to be modified.

https://setuptools.pypa.io/en/latest/history.html#breaking-changes